### PR TITLE
Extract documentation for Trait_ too.

### DIFF
--- a/src/Compiler/IntermediateRepresentation/Into.php
+++ b/src/Compiler/IntermediateRepresentation/Into.php
@@ -143,11 +143,12 @@ class Into extends NodeVisitorAbstract
 
             $this->_file[] = $interface;
         } elseif ($node instanceof Node\Stmt\Trait_) {
-            $traitNode        = $node;
-            $trait            = new Trait_($traitNode->namespacedName->toString());
-            $trait->lineStart = $traitNode->getAttribute('startLine');
-            $trait->lineEnd   = $traitNode->getAttribute('endLine');
-            $trait->methods   = $this->intoMethods($traitNode);
+            $traitNode            = $node;
+            $trait                = new Trait_($traitNode->namespacedName->toString());
+            $trait->lineStart     = $traitNode->getAttribute('startLine');
+            $trait->lineEnd       = $traitNode->getAttribute('endLine');
+            $trait->documentation = new Documentation(Parser::extractFromComment($traitNode->getDocComment()));
+            $trait->methods       = $this->intoMethods($traitNode);
 
             $this->_file[] = $trait;
         } elseif ($node instanceof Node\Stmt\Function_) {


### PR DESCRIPTION
When I tried to execute Kitab on one of my projects, I got an error regarding trait processing, the `documentation` property was null.

Now this property will be populated with the Trait doc comment and the documentation generation was successful.