### PR TITLE
feat(atoum) Start runner manually

### DIFF
--- a/sbin/phar.stub.php
+++ b/sbin/phar.stub.php
@@ -1,6 +1,8 @@
 #!/usr/bin/env php
 <?php
 
+use mageekguy\atoum;
+
 define('KITAB_PHAR_NAME', 'Kitab.phar');
 define('KITAB_PHAR_PATH', realpath($_SERVER['argv'][0]));
 
@@ -12,15 +14,7 @@ if (isset($_SERVER['argv'][1]) && 'atoum' === $_SERVER['argv'][1]) {
     // Clean `$_SERVER` for atoum.
     unset($_SERVER['argv'][1]);
 
-    // Manually add the configuration file.
-    mageekguy\atoum\scripts\runner::addConfigurationCallable(
-        function ($script, $runner) {
-            require_once 'phar://' . KITAB_PHAR_NAME . '/src/DocTest/.atoum.php';
-        }
-    );
-
-    // Run atoum.
-    require_once 'phar://' . KITAB_PHAR_NAME . '/vendor/atoum/atoum/scripts/runner.php';
+    require_once 'phar://' . KITAB_PHAR_NAME . '/src/DocTest/Runner.phar.php';
 } else {
     require_once 'phar://' . KITAB_PHAR_NAME . '/src/Bin/Kitab.php';
 }

--- a/src/DocTest/Runner.phar.php
+++ b/src/DocTest/Runner.phar.php
@@ -1,0 +1,21 @@
+<?php
+
+require_once 'phar://' . KITAB_PHAR_NAME . '/vendor/atoum/atoum/scripts/runner.php';
+
+use mageekguy\atoum\scripts;
+
+// Disable autorun.
+scripts\runner::disableAutorun();
+
+// Allocate the default runner.
+$runner = new scripts\runner(scripts\runner);
+
+// Manually add the configuration file.
+$runner->useConfigurationCallable(
+    function ($script, $runner) {
+        require_once 'phar://' . KITAB_PHAR_NAME . '/src/DocTest/.atoum.php';
+    }
+);
+
+// Run atoum.
+$runner->run();


### PR DESCRIPTION
The autorunner adds an error handler which exits (with code 3). This is something we don't want. Consequently, we disable the autorunner, and we start the runner manually.

cc @jubianchi @mageekguy @vonglasow 