### PR TITLE
feat(doctest) Remove `use` statements in test cases

### DIFF
--- a/src/Compiler/Parser.php
+++ b/src/Compiler/Parser.php
@@ -89,28 +89,6 @@ class Parser
     protected static $_phpPrettyPrinter = null;
 
     /**
-     * When allocating a `Parser` instance, a PHP-Parser instance is created
-     * and stored in `self::$_phpParser` only once. Also, a pre-configured
-     * traverser is created and stored in `self::$_phpTraverser` too.
-     */
-    public function __construct()
-    {
-        if (null === self::$_phpParser) {
-            self::$_phpParser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
-        }
-
-        if (null === self::$_phpTraverser) {
-            self::$_phpTraverser = new NodeTraverser();
-            self::$_phpTraverser->addVisitor(new NodeVisitor\NameResolver());
-        }
-
-        if (null === self::$_phpPrettyPrinter) {
-            self::$_phpPrettyPrinter = new PrettyPrinter\Standard(['shortArraySyntax' => true]);
-        }
-    }
-
-    /**
-
      * The `parse` methods parses a file aiming at containing PHP code, and
      * produces the Intermediate Representation of it if valid. [Get more
      * information about the general workflow](kitab/compiler/index.html).
@@ -181,6 +159,10 @@ class Parser
      */
     public static function getPhpParser(): ParserMultiple
     {
+        if (null === self::$_phpParser) {
+            self::$_phpParser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
+        }
+
         return self::$_phpParser;
     }
 
@@ -189,6 +171,11 @@ class Parser
      */
     protected static function getTraverser(): NodeTraverser
     {
+        if (null === self::$_phpTraverser) {
+            self::$_phpTraverser = new NodeTraverser();
+            self::$_phpTraverser->addVisitor(new NodeVisitor\NameResolver());
+        }
+
         return self::$_phpTraverser;
     }
 
@@ -197,6 +184,10 @@ class Parser
      */
     public static function getPhpPrettyPrinter(): PrettyPrinter\Standard
     {
+        if (null === self::$_phpPrettyPrinter) {
+            self::$_phpPrettyPrinter = new PrettyPrinter\Standard(['shortArraySyntax' => true]);
+        }
+
         return self::$_phpPrettyPrinter;
     }
 

--- a/src/Compiler/Target/DocTest/DocTest.php
+++ b/src/Compiler/Target/DocTest/DocTest.php
@@ -215,7 +215,7 @@ class DocTest implements Target
     protected function unfoldCode(string $phpCode): string
     {
         $ast = Parser::getPhpParser()->parse('<?php ' . $phpCode);
-        self::getPhpTraverser()->traverse($ast);
+        $ast = self::getPhpTraverser()->traverse($ast);
 
         return Parser::getPhpPrettyPrinter()->prettyPrint($ast);
     }
@@ -294,6 +294,7 @@ class DocTest implements Target
         if (null === self::$_phpTraverser) {
             self::$_phpTraverser = new NodeTraverser();
             self::$_phpTraverser->addVisitor(new NodeVisitor\NameResolver());
+            self::$_phpTraverser->addVisitor(new IntoTestCaseBody());
         }
 
         return self::$_phpTraverser;

--- a/src/Compiler/Target/DocTest/DocTest.php
+++ b/src/Compiler/Target/DocTest/DocTest.php
@@ -125,13 +125,14 @@ class DocTest implements Target
 
         return
             sprintf(
-                'namespace Kitab\Generated\DocTest%s;' . "\n\n" .
+                'namespace Kitab\Generated\DocTest%s {' . "\n\n" .
                 'class %s extends \Kitab\DocTest\Suite' . "\n" .
                 '{',
                 $entity->inNamespace() ? '\\' . $entity->getNamespaceName() : '',
                 $this->computeTestSuiteShortName($entity->getShortName(), $entity->name)
             ) .
             $testCases .
+            '}' . "\n\n" .
             '}';
 
 

--- a/src/Compiler/Target/DocTest/IntoTestCaseBody.php
+++ b/src/Compiler/Target/DocTest/IntoTestCaseBody.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Hoa
+ *
+ *
+ * @license
+ *
+ * New BSD License
+ *
+ * Copyright © 2007-2017, Hoa community. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Hoa nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software without
+ *       specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace Kitab\Compiler\Target\DocTest;
+
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+
+/**
+ * A visitor to transform an Abstract Syntax Tree (AST) into a test case body
+ * candidate.
+ *
+ * So far, it applies the following transformations:
+ *
+ *   * Remove the `use` statements (assuming all names have been resolved).
+ *
+ * # Examples
+ *
+ * ```php
+ * $code = '<?php use A\B\C; new C();';
+ * $ast  = Kitab\Compiler\Parser::getPhpParser()->parse($code);
+
+ * $traverser = new PhpParser\NodeTraverser();
+ * $traverser->addVisitor(new PhpParser\NodeVisitor\NameResolver());
+ * $traverser->addVisitor(new Kitab\Compiler\Target\DocTest\IntoTestCaseBody());
+ *
+ * $ast = $traverser->traverse($ast);
+ *
+ * $testCaseCandidate = Kitab\Compiler\Parser::getPhpPrettyPrinter()->prettyPrint($ast);
+ *
+ * assert('new \A\B\C();' === $testCaseCandidate);
+ * ```
+ */
+class IntoTestCaseBody extends NodeVisitorAbstract
+{
+    public function leaveNode(Node $node) {
+        if ($node instanceof Node\Stmt\Use_ ||
+            $node instanceof Node\Stmt\GroupUse) {
+            return NodeTraverser::REMOVE_NODE;
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
If an example contains a `use` statement, all the names are correctly resolved but the `use` statement stays in the test case body, which leads to a PHP syntax error. This PR compiles code blocks into test case candidate, with one rule so far: Remove the `use` statements.