### PR TITLE
fix(option) Reorder utilities to display documentation

### DIFF
--- a/src/Bin/Compile.php
+++ b/src/Bin/Compile.php
@@ -221,10 +221,10 @@ class Compile extends Console\Dispatcher\Kit
             }
 
             $utilities = [
-                'open',
                 'xdg-open',
                 'gnome-open',
-                'kde-open'
+                'kde-open',
+                'open'
             ];
 
             foreach ($utilities as $utility) {


### PR DESCRIPTION
`open` and `xdg-open` are available on ubuntu, try `xdg-open` first
Fix hoaproject/Kitab#32